### PR TITLE
Downgrade elasticsearch-rest-high-level-client to 6.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Go to **Manage Jenkins > System Configuration > Logging to Elasticsearch for Pip
 
 ### Limitations
 
-Currently the plugin is only able to push the logs to Elasticsearch but the way back to read the logs from ElasticSearch and display in Jenkins is not yet implemented.
-The initial scope of this plugin was to use it it in a [JenkinsFileRunner](https://github.com/jenkinsci/jenkinsfile-runner) scenario.
+The Elasticsearch [Java High Level REST Client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high.html)
+used by this plugin [should match](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-compatibility.html) the Elasticsearch server version in order to prevent unexpected results.
 
+In order to not only support the latest Elasticsearch version, and since we did not experience any issues (client: 6.x, server: 7.x), [we decided](https://github.com/SAP/elasticsearch-logs-plugin/issues/13) to stay on a smaller client major version. If you experience any problems please create a GitHub issue.
 
 ### Known Issues
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.3.1</version>
+            <version>6.8.3</version>
         </dependency>
         <dependency>
         	<groupId>org.jenkinsci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,9 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>0.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>0.9</revision>
-        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,12 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>${revision}-ES${elasticsearch.majorversion}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>0.9</revision>
+        <!-- elasticsearch.majorversion has to match major version of elasticsearch-rest-high-level-client -->
+        <elasticsearch.majorversion>6</elasticsearch.majorversion>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,10 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>${revision}-ES${elasticsearch.majorversion}${changelist}</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>0.9</revision>
-        <!-- elasticsearch.majorversion has to match major version of elasticsearch-rest-high-level-client -->
-        <elasticsearch.majorversion>6</elasticsearch.majorversion>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>


### PR DESCRIPTION
fixes https://github.com/SAP/elasticsearch-logs-plugin/issues/11

Needs to be tested, with Elasticsearch 6.x and higher versions.