### PR TITLE
Switch to latest elasticsearch-rest-high-level-client 6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>6.8.3</version>
+            <version>6.8.6</version>
         </dependency>
         <dependency>
         	<groupId>org.jenkinsci.plugins</groupId>


### PR DESCRIPTION
fixes https://nvd.nist.gov/vuln/detail/CVE-2019-7619