### PR TITLE
Fix null bug with connectionTimeout parameter

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
@@ -134,7 +134,7 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
 
     public int getConnectionTimeoutMillisOrDefault() {
         if(connectionTimeoutMillis == null) return CONNECTION_TIMEOUT_DEFAULT;
-        if(connectionTimeoutMillis < -1) return -1;
+        if(connectionTimeoutMillis < 0) return CONNECTION_TIMEOUT_DEFAULT;
         return connectionTimeoutMillis;
     }
 

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
@@ -111,7 +111,9 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
         if (runIdProvider == null) {
             runIdProvider = new DefaultRunIdProvider("");
         }
-
+        if (connectionTimeoutMillis == null || connectionTimeoutMillis < 0) {
+            connectionTimeoutMillis = CONNECTION_TIMEOUT_DEFAULT;
+        }
         if (url == null) {
             String protocol = "http";
             if (ssl) {

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
@@ -132,8 +132,10 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
         return connectionTimeoutMillis;
     }
 
-    public Integer getConnectionTimeoutMillisOrDefault() {
-        return (connectionTimeoutMillis == null || connectionTimeoutMillis < -1) ? CONNECTION_TIMEOUT_DEFAULT : connectionTimeoutMillis;
+    public int getConnectionTimeoutMillisOrDefault() {
+        if(connectionTimeoutMillis == null) return CONNECTION_TIMEOUT_DEFAULT;
+        if(connectionTimeoutMillis < -1) return -1;
+        return connectionTimeoutMillis;
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
@@ -93,7 +93,7 @@ public class ElasticSearchWriteAccessDirect extends ElasticSearchWriteAccess {
                 }
             }
             this.uri = new URI(config.getUrl());
-            this.connectionTimeout = Integer.parseInt(config.getConnectionTimeoutMillis());
+            this.connectionTimeout = config.getConnectionTimeoutMillisOrDefault();
         } else {
             this.username = null;
             this.password = null;

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
@@ -93,7 +93,7 @@ public class ElasticSearchWriteAccessDirect extends ElasticSearchWriteAccess {
                 }
             }
             this.uri = new URI(config.getUrl());
-            this.connectionTimeout = config.getConnectionTimeoutMillisOrDefault();
+            this.connectionTimeout = config.getConnectionTimeoutMillis();
         } else {
             this.username = null;
             this.password = null;

--- a/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
@@ -22,9 +22,9 @@
     </f:entry>
     <f:entry >
       <f:dropdownDescriptorSelector title="RunID Provider" field="runIdProvider"/>
-    </f:entry>  
+    </f:entry>
     <f:entry field="connectionTimeoutMillis" title="Connection Timeout (ms)">
-      <f:textbox/>
+      <f:number clazz="number" min="-1" max="2147483647" default="10000"/>
     </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
@@ -24,7 +24,7 @@
       <f:dropdownDescriptorSelector title="RunID Provider" field="runIdProvider"/>
     </f:entry>
     <f:entry field="connectionTimeoutMillis" title="Connection Timeout (ms)">
-      <f:number clazz="number" min="-1" max="2147483647" default="10000"/>
+      <f:number clazz="number" min="0" max="2147483647" default="10000"/>
     </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/help-connectionTimeoutMillis.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/help-connectionTimeoutMillis.html
@@ -1,3 +1,4 @@
 <div>
   Timeout in milliseconds for connection timeouts to Elasticsearch.
+  A timeout value of zero is interpreted as an infinite timeout.
 </div>


### PR DESCRIPTION
The fix should prevent such Exceptions. Don't know why it didn't happen in local tests (also without explicit connectionTimeout in the config.
```
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es.ElasticSearchWriteAccessDirect.<init>(ElasticSearchWriteAccessDirect.java:96)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es.ElasticSearchWriteAccessDirect$MeSupplier.get(ElasticSearchWriteAccessDirect.java:275)
Caused: java.lang.RuntimeException: Could not create ElasticSearchWriteAccessDirect
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es.ElasticSearchWriteAccessDirect$MeSupplier.get(ElasticSearchWriteAccessDirect.java:277)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es.ElasticSearchWriteAccessDirect$MeSupplier.get(ElasticSearchWriteAccessDirect.java:266)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticSearchRunConfiguration.createWriteAccess(ElasticSearchRunConfiguration.java:96)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticSearchSender.getElasticSearchWriter(ElasticSearchSender.java:82)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticSearchSender.access$300(ElasticSearchSender.java:25)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticSearchSender$ElasticSearchOutputStream.eol(ElasticSearchSender.java:145)
	at hudson.console.LineTransformationOutputStream.eol(LineTransformationOutputStream.java:60)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:56)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticSearchSender$ElasticSearchOutputStream.write(ElasticSearchSender.java:124)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:74)
	at java.io.PrintStream.write(PrintStream.java:480)
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
	at sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:291)
	at sun.nio.cs.StreamEncoder.flushBuffer(StreamEncoder.java:104)
	at java.io.OutputStreamWriter.flushBuffer(OutputStreamWriter.java:185)
	at java.io.PrintStream.write(PrintStream.java:527)
	at java.io.PrintStream.print(PrintStream.java:669)
	at java.io.PrintStream.println(PrintStream.java:806)
	at hudson.Functions.printStackTrace(Functions.java:1592)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:593)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:333)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:427)
Caused: java.util.concurrent.ExecutionException
	at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:77)
	at io.jenkins.jenkinsfile.runner.Runner.run(Runner.java:70)
Caused: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at io.jenkins.jenkinsfile.runner.JenkinsfileRunnerLauncher.launch(JenkinsfileRunnerLauncher.java:131)
	at io.jenkins.jenkinsfile.runner.App.run(App.java:14)
	at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.run(Bootstrap.java:284)
	at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.main(Bootstrap.java:122)
```