### PR TITLE
fix remoting

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
@@ -218,7 +218,7 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
         return "https".equals(scheme);
     }
 
-    private byte[] getKeyStoreBytes() throws IOException {
+    public byte[] getKeyStoreBytes() throws IOException {
         KeyStore keyStore = getCustomKeyStore();
         if (isSsl() && keyStore != null) {
             ByteArrayOutputStream b = new ByteArrayOutputStream(2048);
@@ -258,14 +258,14 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
             throw new IOException(e);
         }
 
-        return new ElasticSearchRunConfiguration(uri, username, password, getKeyStoreBytes(), isSaveAnnotations(), getUniqueRunId(run),
+        return new ElasticSearchRunConfiguration(uri, username, password, isSaveAnnotations(), getUniqueRunId(run),
                 getRunIdProvider().getRunId(run), getWriteAccessFactory(), getConnectionTimeoutMillis());
     }
 
     // Can be overwritten in tests
     @CheckForNull
     @Restricted(NoExternalUse.class)
-    protected Supplier<ElasticSearchWriteAccess> getWriteAccessFactory() {
+    protected Supplier<ElasticSearchWriteAccess> getWriteAccessFactory() throws IOException {
         return elasticsearchWriteAccess.getSupplier();
     }
 

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfiguration.java
@@ -50,7 +50,7 @@ public class ElasticSearchRunConfiguration implements Serializable {
 
     private final String runIdJsonString;
 
-    public ElasticSearchRunConfiguration(URI uri, String username, String password, byte[] keyStoreBytes, boolean saveAnnotations,
+    public ElasticSearchRunConfiguration(URI uri, String username, String password, boolean saveAnnotations,
             String uid, JSONObject runId, Supplier<ElasticSearchWriteAccess> writeAccessFactory, int connectionTimeoutMillis) {
         super();
         this.uri = uri;

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/ElasticSearchWriteAccess.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/ElasticSearchWriteAccess.java
@@ -21,6 +21,6 @@ public abstract class ElasticSearchWriteAccess extends AbstractDescribableImpl<E
      * of this object at a later point in time.
      * @return
      */
-    public abstract Supplier<ElasticSearchWriteAccess> getSupplier();
+    public abstract Supplier<ElasticSearchWriteAccess> getSupplier() throws IOException;
 
 }

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfigurationTest.java
@@ -16,7 +16,7 @@ public class ElasticSearchRunConfigurationTest {
     public void testGetIndices() throws URISyntaxException {
         ElasticSearchRunConfiguration config = new ElasticSearchRunConfiguration(
                 new URI("http://localhost:9200/index1/_doc"),
-                null, null, null, false, null, JSONObject.fromObject("{}"), null, CONNECTION_TIMEOUT_DEFAULT);
+                null, null, false, null, JSONObject.fromObject("{}"), null, CONNECTION_TIMEOUT_DEFAULT);
         String[] indices = config.getIndices();
         Assert.assertEquals(1, indices.length);
         Assert.assertEquals("index1", indices[0]);

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchTestConfiguration.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchTestConfiguration.java
@@ -22,7 +22,7 @@ class ElasticSearchTestConfiguration extends ElasticSearchConfiguration {
 
     @Override
     protected Supplier<ElasticSearchWriteAccess> getWriteAccessFactory() {
-        return () -> new ElasticSearchWriteAccessDirect(null, null, null, CONNECTION_TIMEOUT_DEFAULT) {
+        return () -> new ElasticSearchWriteAccessDirect(null, null, null, CONNECTION_TIMEOUT_DEFAULT, null) {
             @Override
             public void push(String data) throws IOException {
                 Map<String, Object> map = JSONObject.fromObject(data);

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchWriteAccessMock.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchWriteAccessMock.java
@@ -6,7 +6,6 @@ import static io.jenkins.plugins.pipeline_elasticsearch_logs.testutils.JSONUtils
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.KeyStore;
 import java.util.ArrayList;
 
 import org.apache.http.conn.ConnectTimeoutException;
@@ -19,17 +18,13 @@ import io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es.ElasticSea
  */
 public class ElasticSearchWriteAccessMock extends ElasticSearchWriteAccessDirect {
 
-    private ArrayList<String> entries = new ArrayList<String>();
+    private ArrayList<String> entries = new ArrayList<>();
     private boolean printToLog = false;
     private boolean failConnection = false;
 
     public ElasticSearchWriteAccessMock(boolean printToLog) throws URISyntaxException {
-        super(new URI("http://localhost:9200/jenkins/_doc"), "test", "test", CONNECTION_TIMEOUT_DEFAULT);
+        super(new URI("http://localhost:9200/jenkins/_doc"), "test", "test", CONNECTION_TIMEOUT_DEFAULT, null);
         this.printToLog = printToLog;
-    }
-
-    @Override
-    public void setTrustKeyStore(KeyStore trustKeyStore) {
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest.java
@@ -150,7 +150,7 @@ public class IntegrationTest {
     @Test
     public void testPipelinePushLogsWithConnectionIssues() throws Exception {
         // SETUP
-        ElasticSearchWriteAccess elasticSearchAccess = new ElasticSearchWriteAccessDirect(new URI("http://wrongurl.does.not.exist"), null, null, CONNECTION_TIMEOUT_DEFAULT);
+        ElasticSearchWriteAccess elasticSearchAccess = new ElasticSearchWriteAccessDirect(new URI("http://wrongurl.does.not.exist"), null, null, CONNECTION_TIMEOUT_DEFAULT, null);
         configureElasticsearchPlugin(true, false, elasticSearchAccess);
 
         WorkflowJob project = j.createProject(WorkflowJob.class);


### PR DESCRIPTION
a git checkout on an agent will create a logger running on the agent.
This means the Elasticsearch Direct writer needs to be serializable which
is not the case yet.