### PR TITLE
allow to remove annotations from logfile

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration.java
@@ -67,6 +67,8 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
 
     private Boolean saveAnnotations = true;
 
+    private Boolean writeAnnotationsToLogFile = true;
+
     private RunIdProvider runIdProvider;
 
     private ElasticSearchWriteAccess elasticsearchWriteAccess;
@@ -77,7 +79,7 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
 
     @CheckForNull
     private Integer connectionTimeoutMillis;
-    
+
     @DataBoundConstructor
     public ElasticSearchConfiguration(String url) throws URISyntaxException {
         this.url = url;
@@ -105,6 +107,9 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
     protected Object readResolve() {
         if (saveAnnotations == null) {
             saveAnnotations = true;
+        }
+        if (writeAnnotationsToLogFile == null) {
+            writeAnnotationsToLogFile = true;
         }
         if (runIdProvider == null) {
             runIdProvider = new DefaultRunIdProvider("");
@@ -143,6 +148,15 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
     @DataBoundSetter
     public void setSaveAnnotations(boolean saveAnnotations) {
         this.saveAnnotations = saveAnnotations;
+    }
+
+    public boolean isWriteAnnotationsToLogFile() {
+        return writeAnnotationsToLogFile;
+    }
+
+    @DataBoundSetter
+    public void setWriteAnnotationsToLogFile(boolean writeAnnotationsToLogFile) {
+        this.writeAnnotationsToLogFile = writeAnnotationsToLogFile;
     }
 
     public String getCertificateId() {
@@ -259,7 +273,7 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
         }
 
         return new ElasticSearchRunConfiguration(uri, username, password, isSaveAnnotations(), getUniqueRunId(run),
-                getRunIdProvider().getRunId(run), getWriteAccessFactory(), getConnectionTimeoutMillis());
+                getRunIdProvider().getRunId(run), getWriteAccessFactory(), getConnectionTimeoutMillis(), isWriteAnnotationsToLogFile());
     }
 
     // Can be overwritten in tests
@@ -290,7 +304,7 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
     @Extension
     @Symbol("elasticsearch")
     public static class DescriptorImpl extends Descriptor<ElasticSearchConfiguration> {
-        
+
         public static ListBoxModel doFillCredentialsIdItems(@QueryParameter String credentialsId) {
             StandardUsernameListBoxModel model = new StandardUsernameListBoxModel();
 
@@ -307,16 +321,16 @@ public class ElasticSearchConfiguration extends AbstractDescribableImpl<ElasticS
 
             return model;
         }
-        
+
         public FormValidation doCheckConnectionTimeoutMillis(@QueryParameter("value") Integer value) {
             int newValue = ensureCorrectConnectionTimeoutMillis(value);
-            if(value == null || newValue != (int)value) {
+            if(value == null || newValue != value) {
                 return FormValidation.warning("Illegal value - default " + newValue + " is used instead.");
             }
             if(value == 0) return FormValidation.ok("This means no connection timeout is used");
             return FormValidation.ok();
         }
-        
+
         public FormValidation doCheckUrl(@QueryParameter("value") String value) {
             if (StringUtils.isBlank(value)) {
                 return FormValidation.warning("URL must not be empty");

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfiguration.java
@@ -44,6 +44,8 @@ public class ElasticSearchRunConfiguration implements Serializable {
 
     private final boolean saveAnnotations;
 
+    private final boolean writeAnnotationsToLogFile;
+
     private final String uid;
 
     private Supplier<ElasticSearchWriteAccess> writeAccessFactory;
@@ -51,7 +53,8 @@ public class ElasticSearchRunConfiguration implements Serializable {
     private final String runIdJsonString;
 
     public ElasticSearchRunConfiguration(URI uri, String username, String password, boolean saveAnnotations,
-            String uid, JSONObject runId, Supplier<ElasticSearchWriteAccess> writeAccessFactory, int connectionTimeoutMillis) {
+            String uid, JSONObject runId, Supplier<ElasticSearchWriteAccess> writeAccessFactory, int connectionTimeoutMillis,
+            boolean writeAnnotationsToLogFile) {
         super();
         this.uri = uri;
         this.username = username;
@@ -60,6 +63,7 @@ public class ElasticSearchRunConfiguration implements Serializable {
         this.uid = uid;
         this.writeAccessFactory = writeAccessFactory;
         this.saveAnnotations = saveAnnotations;
+        this.writeAnnotationsToLogFile = writeAnnotationsToLogFile;
     }
 
     public String getUid() {
@@ -68,6 +72,10 @@ public class ElasticSearchRunConfiguration implements Serializable {
 
     public boolean isSaveAnnotations() {
         return saveAnnotations;
+    }
+
+    public boolean isWriteAnnotationsToLogFile() {
+        return writeAnnotationsToLogFile;
     }
 
     public URI getUri() {
@@ -95,7 +103,7 @@ public class ElasticSearchRunConfiguration implements Serializable {
     public ElasticSearchWriteAccess createWriteAccess() throws URISyntaxException {
         return writeAccessFactory.get();
     }
-    
+
     public String[] getIndices() {
         String path = uri.getPath();
         while (path.startsWith("/"))

--- a/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/config.jelly
@@ -20,6 +20,9 @@
     <f:entry field="saveAnnotations" title="Save Annotations">
       <f:checkbox default="true"/>
     </f:entry>
+    <f:entry field="writeAnnotationsToLogFile" title="Write Annotations to log file">
+      <f:checkbox default="true"/>
+    </f:entry>
     <f:entry >
       <f:dropdownDescriptorSelector title="RunID Provider" field="runIdProvider"/>
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/help-writeAnnotationsToLogFile.html
+++ b/src/main/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchConfiguration/help-writeAnnotationsToLogFile.html
@@ -1,0 +1,4 @@
+<div>
+  Write the annotations to the log file in file system.<br/>
+  When using Jenkins File Runner this should be disabled as the annotations can lead to exceptions in JFR which block the termination.
+</div>

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchRunConfigurationTest.java
@@ -16,7 +16,7 @@ public class ElasticSearchRunConfigurationTest {
     public void testGetIndices() throws URISyntaxException {
         ElasticSearchRunConfiguration config = new ElasticSearchRunConfiguration(
                 new URI("http://localhost:9200/index1/_doc"),
-                null, null, false, null, JSONObject.fromObject("{}"), null, CONNECTION_TIMEOUT_DEFAULT);
+                null, null, false, null, JSONObject.fromObject("{}"), null, CONNECTION_TIMEOUT_DEFAULT, true);
         String[] indices = config.getIndices();
         Assert.assertEquals(1, indices.length);
         Assert.assertEquals("index1", indices[0]);


### PR DESCRIPTION
in Jenkins file runner we observed a race condition between the build
writing the log and JFR reading the log to print to stdout.
Every now and then it seems the annotations are not fully written,
leading to exceptions and the main thread of JFR dies but as other
threads are not terminated JFR effectively hangs.