### PR TITLE
Update script-security dependency to 1.75

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1.72</version>
+                <version>1.75</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Although this (vulnerable) version is not used at runtime, let's update it.