### PR TITLE
Remove snapshot, release 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>0.10.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.176.4</jenkins.version>


### PR DESCRIPTION
The release tags so far point to a single snapshot version. Altough we consume the plugin by source (we should have a real release) the version in the pom.xml should match the release tag version.