### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
+        os: [ubuntu-latest] # Other OS builds removed. Central build is a unix build anyway. // [windows-latest, macOS-latest]
+        # Jenkins core dependency causes issues during deleting the temporary workspace in the test 'IntegrationTest.testPipelinePushLogsWithConnectionIssues'
+        # "CompositeIO Unable to delete 'D:\a\elasticsearch-logs-plugin\elasticsearch-logs-plugin\target\tmp\j h1981224811615637958'"
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- Adapt the jenkins.tools.bom artifact ID in the dependencyManagement section
              if the Jenkins core version is changed -->
-        <jenkins.version>2.319.1</jenkins.version>
+        <jenkins.version>2.332.3</jenkins.version>
         <useBeta>true</useBeta>
 
         <mock-slave.version>109.vac7845f10470</mock-slave.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
     <version>0.11.0</version>
     <packaging>hpi</packaging>
     <properties>
+        <!-- Adapt the jenkins.tools.bom artifact ID in the dependencyManagement section
+             if the Jenkins core version is changed -->
         <jenkins.version>2.319.1</jenkins.version>
         <useBeta>true</useBeta>
 
@@ -22,6 +24,7 @@
         <fluency.version>2.6.4</fluency.version>
         <jsr305.version>3.0.2</jsr305.version>
 
+        <bom-2.319.x.version>1342.v729ca_3818e88</bom-2.319.x.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
     <name>Pipeline Logging via Elastic Search</name>
@@ -131,8 +134,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.319.x</artifactId>
-                <!-- Latest version goes here -->
-                <version>1342.v729ca_3818e88</version>
+                <version>${bom-2.319.x.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,11 @@
     <version>0.11.0</version>
     <packaging>hpi</packaging>
     <properties>
-        <!-- Adapt the jenkins.tools.bom artifact ID in the dependencyManagement section
-             if the Jenkins core version is changed -->
+        <!-- If the "jenkins.version" is changed you also need to adjust:
+            - the major and minor version in the "<bom-#.###.x.version>" tag a few lines below (keep "x" as patch version)
+            - in the dependencyManagement section the "io.jenkins.tools.bom:bom-#.###.x" artifactId and version property name.
+            See also https://github.com/jenkinsci/bom#usage and https://www.jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-plugin-bom
+        -->
         <jenkins.version>2.332.3</jenkins.version>
         <useBeta>true</useBeta>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,41 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.176.4</jenkins.version>
-        <java.level>8</java.level>
         <useBeta>true</useBeta>
-        <workflow-api-plugin.version>2.40</workflow-api-plugin.version>
-        <fluency.version>2.4.1</fluency.version>
+        <java.level>8</java.level>
+
+        <workflow-api.version>2.40</workflow-api.version>
+        <fluency.version>2.6.4</fluency.version>
+        <workflow-job.version>2.39</workflow-job.version>
+        <workflow-basic-steps.version>2.20</workflow-basic-steps.version>
+        <workflow-durable-task-step.version>2.35</workflow-durable-task-step.version>
+        <mock-slave.version>1.14</mock-slave.version>
+        <pipeline-stage-step.version>2.3</pipeline-stage-step.version>
+        <instance-identity.version>2.2</instance-identity.version>
+        <unique-id.version>2.2.0</unique-id.version>
+        <pipeline-model-definition.version>1.7.0</pipeline-model-definition.version>
+        <pipeline-stage-tags-metadata.version>1.7.0</pipeline-stage-tags-metadata.version>
+        <jackson2-api.version>2.11.1</jackson2-api.version>
+
+        <workflow-support.version>3.4</workflow-support.version>
+        <workflow-step-api.version>2.22</workflow-step-api.version>
+        <structs.version>1.20</structs.version>
+        <symbol-annotation.version>1.20</symbol-annotation.version>
+        <scm-api.version>2.6.3</scm-api.version>
+        <credentials.version>2.3.7</credentials.version>
+        <script-security.version>1.75</script-security.version>
+        <apache-httpcomponents-client-4-api.version>4.5.10-2.0</apache-httpcomponents-client-4-api.version>
+        <httpcore-nio.version>4.4.11</httpcore-nio.version>
+        <mailer.version>1.32</mailer.version>
+        <workflow-cps.version>2.80</workflow-cps.version>
+        <workflow-scm-step.version>2.11</workflow-scm-step.version>
+        <ssh-credentials.version>1.17.3</ssh-credentials.version>
+        <commons-lang3.version>3.7</commons-lang3.version>
+        <slf4j-api.version>1.7.30</slf4j-api.version>
     </properties>
     <name>Pipeline Logging via Elastic Search</name>
     <repositories>
@@ -37,35 +64,35 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api-plugin.version}</version>
+            <version>${workflow-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api-plugin.version}</version>
+            <version>${workflow-api.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.39</version>
+            <version>${workflow-job.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.20</version>
+            <version>${workflow-basic-steps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.35</version>
+            <version>${workflow-durable-task-step.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mock-slave</artifactId>
-            <version>1.14</version>
+            <version>${mock-slave.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -75,7 +102,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.3</version>
+            <version>${pipeline-stage-step.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -88,13 +115,13 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.2</version>
+            <version>${instance-identity.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>unique-id</artifactId>
-            <version>2.2.0</version>
+            <version>${unique-id.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -103,13 +130,13 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.7.0</version>
+            <version>${pipeline-model-definition.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-stage-tags-metadata</artifactId>
-            <version>1.7.0</version>
+            <version>${pipeline-stage-tags-metadata.version}</version>
         </dependency>
         <dependency>
         	<groupId>org.komamitsu</groupId>
@@ -124,7 +151,7 @@
         <dependency>
         	<groupId>org.jenkins-ci.plugins</groupId>
         	<artifactId>jackson2-api</artifactId>
-        	<version>2.11.1</version>
+        	<version>${jackson2-api.version}</version>
         </dependency>
     </dependencies>
     <dependencyManagement>
@@ -132,78 +159,78 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-support</artifactId>
-                <version>3.4</version>
+                <version>${workflow-support.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-step-api</artifactId>
-                <version>2.22</version>
+                <version>${workflow-step-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
-                <version>1.20</version>
+                <version>${structs.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
-                <version>1.20</version>
+                <version>${symbol-annotation.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
-                <version>2.6.3</version>
+                <version>${scm-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
-                <version>2.3.7</version>
+                <version>${credentials.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1.75</version>
+                <version>${script-security.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>apache-httpcomponents-client-4-api</artifactId>
-                <version>4.5.10-2.0</version>
+                <version>${apache-httpcomponents-client-4-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore-nio</artifactId>
-                <version>4.4.11</version>
+                <version>${httpcore-nio.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>mailer</artifactId>
-                <version>1.32</version>
+                <version>${mailer.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
-                <version>2.80</version>
+                <version>${workflow-cps.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-scm-step</artifactId>
-                <version>2.11</version>
+                <version>${workflow-scm-step.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ssh-credentials</artifactId>
-                <version>1.17.3</version>
+                <version>${ssh-credentials.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.30</version>
+                <version>${slf4j-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
         <fluency.version>2.6.4</fluency.version>
         <jsr305.version>3.0.2</jsr305.version>
 
-        <bom-2.319.x.version>1342.v729ca_3818e88</bom-2.319.x.version>
+        <!-- Latest releases see: https://github.com/jenkinsci/bom/releases -->
+        <bom-2.332.x.version>1409.v7659b_c072f18</bom-2.332.x.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
     <name>Pipeline Logging via Elastic Search</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.49</version>
+        <version>4.40</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,9 +14,8 @@
     <version>0.10.1</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.319.1</jenkins.version>
         <useBeta>true</useBeta>
-        <java.level>8</java.level>
 
         <workflow-api.version>2.40</workflow-api.version>
         <fluency.version>2.6.4</fluency.version>
@@ -30,6 +29,7 @@
         <pipeline-model-definition.version>1.7.0</pipeline-model-definition.version>
         <pipeline-stage-tags-metadata.version>1.7.0</pipeline-stage-tags-metadata.version>
         <jackson2-api.version>2.11.1</jackson2-api.version>
+        <jsr305.version>3.0.2</jsr305.version>
 
         <workflow-support.version>3.4</workflow-support.version>
         <workflow-step-api.version>2.22</workflow-step-api.version>
@@ -152,6 +152,11 @@
         	<groupId>org.jenkins-ci.plugins</groupId>
         	<artifactId>jackson2-api</artifactId>
         	<version>${jackson2-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <workflow-scm-step.version>2.11</workflow-scm-step.version>
         <ssh-credentials.version>1.17.3</ssh-credentials.version>
         <commons-lang3.version>3.7</commons-lang3.version>
-        <slf4j-api.version>1.7.30</slf4j-api.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
     <name>Pipeline Logging via Elastic Search</name>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>${bom-2.319.x.version}</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>${bom-2.332.x.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,40 +11,17 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-elasticsearch-logs</artifactId>
-    <version>0.10.1</version>
+    <version>0.11.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.319.1</jenkins.version>
         <useBeta>true</useBeta>
 
-        <workflow-api.version>2.40</workflow-api.version>
-        <fluency.version>2.6.4</fluency.version>
-        <workflow-job.version>2.39</workflow-job.version>
-        <workflow-basic-steps.version>2.20</workflow-basic-steps.version>
-        <workflow-durable-task-step.version>2.35</workflow-durable-task-step.version>
         <mock-slave.version>1.14</mock-slave.version>
-        <pipeline-stage-step.version>2.3</pipeline-stage-step.version>
-        <instance-identity.version>2.2</instance-identity.version>
         <unique-id.version>2.2.0</unique-id.version>
-        <pipeline-model-definition.version>1.7.0</pipeline-model-definition.version>
-        <pipeline-stage-tags-metadata.version>1.7.0</pipeline-stage-tags-metadata.version>
-        <jackson2-api.version>2.11.1</jackson2-api.version>
+        <fluency.version>2.6.4</fluency.version>
         <jsr305.version>3.0.2</jsr305.version>
 
-        <workflow-support.version>3.4</workflow-support.version>
-        <workflow-step-api.version>2.22</workflow-step-api.version>
-        <structs.version>1.20</structs.version>
-        <symbol-annotation.version>1.20</symbol-annotation.version>
-        <scm-api.version>2.6.3</scm-api.version>
-        <credentials.version>2.3.7</credentials.version>
-        <script-security.version>1.75</script-security.version>
-        <apache-httpcomponents-client-4-api.version>4.5.10-2.0</apache-httpcomponents-client-4-api.version>
-        <httpcore-nio.version>4.4.11</httpcore-nio.version>
-        <mailer.version>1.32</mailer.version>
-        <workflow-cps.version>2.80</workflow-cps.version>
-        <workflow-scm-step.version>2.11</workflow-scm-step.version>
-        <ssh-credentials.version>1.17.3</ssh-credentials.version>
-        <commons-lang3.version>3.7</commons-lang3.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
     <name>Pipeline Logging via Elastic Search</name>
@@ -64,30 +41,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow-job.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow-basic-steps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>${workflow-durable-task-step.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -102,7 +74,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>${pipeline-stage-step.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -115,7 +86,6 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>${instance-identity.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -130,13 +100,11 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>${pipeline-model-definition.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-stage-tags-metadata</artifactId>
-            <version>${pipeline-stage-tags-metadata.version}</version>
         </dependency>
         <dependency>
         	<groupId>org.komamitsu</groupId>
@@ -151,7 +119,6 @@
         <dependency>
         	<groupId>org.jenkins-ci.plugins</groupId>
         	<artifactId>jackson2-api</artifactId>
-        	<version>${jackson2-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -162,76 +129,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-support</artifactId>
-                <version>${workflow-support.version}</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.319.x</artifactId>
+                <!-- Latest version goes here -->
+                <version>1342.v729ca_3818e88</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-step-api</artifactId>
-                <version>${workflow-step-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>${structs.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>${symbol-annotation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>scm-api</artifactId>
-                <version>${scm-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>credentials</artifactId>
-                <version>${credentials.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>${script-security.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>apache-httpcomponents-client-4-api</artifactId>
-                <version>${apache-httpcomponents-client-4-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore-nio</artifactId>
-                <version>${httpcore-nio.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>mailer</artifactId>
-                <version>${mailer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-cps</artifactId>
-                <version>${workflow-cps.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-scm-step</artifactId>
-                <version>${workflow-scm-step.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>ssh-credentials</artifactId>
-                <version>${ssh-credentials.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
+            <!-- Dependency added to fulfil upper bound dependency enforcer rule -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <jenkins.version>2.319.1</jenkins.version>
         <useBeta>true</useBeta>
 
-        <mock-slave.version>1.14</mock-slave.version>
-        <unique-id.version>2.2.0</unique-id.version>
+        <mock-slave.version>109.vac7845f10470</mock-slave.version>
+        <unique-id.version>2.2.1</unique-id.version>
         <fluency.version>2.6.4</fluency.version>
         <jsr305.version>3.0.2</jsr305.version>
 

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/direct_es/ElasticSearchWriteAccessDirect.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.pipeline_elasticsearch_logs.write.direct_es;
 
-import static com.google.common.collect.Ranges.closedOpen;
+import static com.google.common.collect.Range.closedOpen;
 import static io.jenkins.plugins.pipeline_elasticsearch_logs.Utils.logExceptionAndReraiseWithTruncatedDetails;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;

--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/ElasticSearchTest.java
@@ -57,30 +57,29 @@ public class ElasticSearchTest {
         project.setDefinition(new CpsFlowDefinition("node { echo message: 'hello' }", true));
         jenkinsRule.buildAndAssertSuccess(project);
 
-        assertEquals(22, elasticSearchLoggedLines.size());
+        assertEquals(21, elasticSearchLoggedLines.size());
 
         assertLogLine(0, "buildStart");
         assertLogLine(1, "buildMessage", "Started");
-        assertLogLine(2, "buildMessage", "Running in Durability level: MAX_SURVIVABILITY");
-        assertLogLine(3, "buildMessage", "[Pipeline] Start of Pipeline");
-        assertLogLine(4, "flowGraph::flowStart");
-        assertLogLine(5, "buildMessage", "[Pipeline] node");
-        assertLogLine(6, "flowGraph::nodeStart");
-        // skip 7
-        assertLogLine(8, "buildMessage", "[Pipeline] {");
-        assertLogLine(9, "flowGraph::nodeStart");
-        assertLogLine(10, "buildMessage", "[Pipeline] echo");
-        assertLogLine(11, "flowGraph::atomNodeStart");
-        assertLogLine(12, "nodeMessage", "hello");
-        assertLogLine(13, "buildMessage", "[Pipeline] }");
-        assertLogLine(14, "flowGraph::atomNodeEnd");
-        assertLogLine(15, "buildMessage", "[Pipeline] // node");
-        assertLogLine(16, "flowGraph::nodeEnd");
-        assertLogLine(17, "buildMessage", "[Pipeline] End of Pipeline");
-        assertLogLine(18, "flowGraph::nodeEnd");
-        assertLogLine(19, "flowGraph::flowEnd");
-        assertLogLine(20, "buildMessage", "Finished: SUCCESS");
-        assertLogLine(21, "buildEnd");
+        assertLogLine(2, "buildMessage", "[Pipeline] Start of Pipeline");
+        assertLogLine(3, "flowGraph::flowStart");
+        assertLogLine(4, "buildMessage", "[Pipeline] node");
+        assertLogLine(5, "flowGraph::nodeStart");
+        // skip 6
+        assertLogLine(7, "buildMessage", "[Pipeline] {");
+        assertLogLine(8, "flowGraph::nodeStart");
+        assertLogLine(9, "buildMessage", "[Pipeline] echo");
+        assertLogLine(10, "flowGraph::atomNodeStart");
+        assertLogLine(11, "nodeMessage", "hello");
+        assertLogLine(12, "buildMessage", "[Pipeline] }");
+        assertLogLine(13, "flowGraph::atomNodeEnd");
+        assertLogLine(14, "buildMessage", "[Pipeline] // node");
+        assertLogLine(15, "flowGraph::nodeEnd");
+        assertLogLine(16, "buildMessage", "[Pipeline] End of Pipeline");
+        assertLogLine(17, "flowGraph::nodeEnd");
+        assertLogLine(18, "flowGraph::flowEnd");
+        assertLogLine(19, "buildMessage", "Finished: SUCCESS");
+        assertLogLine(20, "buildEnd");
     }
 
     private void assertLogLine(int lineIndex, String eventType) {

--- a/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPlugin.log.json
+++ b/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPlugin.log.json
@@ -17,14 +17,6 @@
   },
     {
     "eventType": "buildMessage",
-    "message": "Running in Durability level: MAX_SURVIVABILITY",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
     "message": "[Pipeline] Start of Pipeline",
     "annotations": "/.*/",
     "timestamp": "/.*/",

--- a/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPluginReadLogsFromFile.log
+++ b/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPluginReadLogsFromFile.log
@@ -1,8 +1,7 @@
 Started by user SYSTEM
-Running in Durability level: MAX_SURVIVABILITY
 [Pipeline] Start of Pipeline
 [Pipeline] node
-Running on Jenkins in 
+Running on Jenkins in
 [Pipeline] {
 [Pipeline] stage
 [Pipeline] { (Stage 1)

--- a/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPluginReadLogsFromFile.log.json
+++ b/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithElasticsearchPluginReadLogsFromFile.log.json
@@ -17,14 +17,6 @@
   },
     {
     "eventType": "buildMessage",
-    "message": "Running in Durability level: MAX_SURVIVABILITY",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
     "message": "[Pipeline] Start of Pipeline",
     "annotations": "/.*/",
     "timestamp": "/.*/",

--- a/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithSkippedStages.log.json
+++ b/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithSkippedStages.log.json
@@ -17,14 +17,6 @@
   },
     {
     "eventType": "buildMessage",
-    "message": "Running in Durability level: MAX_SURVIVABILITY",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
     "message": "[Pipeline] Start of Pipeline",
     "annotations": "/.*/",
     "timestamp": "/.*/",
@@ -187,7 +179,7 @@
     "predecessors": ["7"],
     "displayName": "Bind credentials to variables : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "stageId": "6",
     "stageName": "S1",
     "duration": "/.*/",
@@ -214,7 +206,7 @@
     "predecessors": ["8"],
     "displayName": "Stage : Body : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -239,7 +231,7 @@
     "predecessors": ["9"],
     "displayName": "Stage : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -316,7 +308,7 @@
     "predecessors": ["12"],
     "displayName": "Stage : Body : End",
     "result": "NOT_BUILT",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -341,7 +333,7 @@
     "predecessors": ["13"],
     "displayName": "Stage : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -418,7 +410,7 @@
     "predecessors": ["16"],
     "displayName": "Stage : Body : End",
     "result": "NOT_BUILT",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -443,7 +435,7 @@
     "predecessors": ["17"],
     "displayName": "Stage : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -468,7 +460,7 @@
     "predecessors": ["18"],
     "displayName": "Allocate node : Body : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "agent": "",
     "timestamp": "/.*/",
@@ -493,7 +485,7 @@
     "predecessors": ["19"],
     "displayName": "Allocate node : End",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "timestamp": "/.*/",
     "timestampMillis": "/.*/",
@@ -507,7 +499,7 @@
     "predecessors": ["20"],
     "displayName": "End of Pipeline",
     "result": "FAILURE",
-    "errorMessage": "doesNotExist",
+    "errorMessage": "Could not find credentials entry with ID 'doesNotExist'",
     "duration": "/.*/",
     "timestamp": "/.*/",
     "timestampMillis": "/.*/",
@@ -516,687 +508,7 @@
   },
     {
     "eventType": "buildMessage",
-    "message": "org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException: doesNotExist",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
-    "timestamp": "/.*/",
-    "timestampMillis": "/.*/",
-    "runId": "/.*/",
-    "uid": "/.*/"
-  },
-    {
-    "eventType": "buildMessage",
-    "message": "/.*at .*/",
+    "message": "ERROR: Could not find credentials entry with ID 'doesNotExist'",
     "timestamp": "/.*/",
     "timestampMillis": "/.*/",
     "runId": "/.*/",

--- a/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithoutElasticsearchPlugin.log
+++ b/src/test/resources/io/jenkins/plugins/pipeline_elasticsearch_logs/IntegrationTest/testPipelineWithoutElasticsearchPlugin.log
@@ -1,8 +1,7 @@
 Started by user SYSTEM
-Running in Durability level: MAX_SURVIVABILITY
 [Pipeline] Start of Pipeline
 [Pipeline] node
-Running on Jenkins in 
+Running on Jenkins in
 [Pipeline] {
 [Pipeline] stage
 [Pipeline] { (Stage 1)


### PR DESCRIPTION
Biggest change is to use the Jenkins plugin BOM which simplifies the dependency management. Everything else remains untouched except some test resources. Here the message output changed a little with the newer Jenkins core and plugin versions.