### PR TITLE
Run emitting steps of the fluency library in a separate thread

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/fluentd/FluentdEventWriter.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/fluentd/FluentdEventWriter.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -36,7 +35,8 @@ public class FluentdEventWriter implements EventWriter {
 
     private transient Fluency fluentd;
     private transient FluentdErrorHandler errorHandler;
-    private ExecutorService executor;
+
+    private ExecutorService executor = Executors.newCachedThreadPool();
 
     FluentdEventWriterConfig config;
 
@@ -74,8 +74,6 @@ public class FluentdEventWriter implements EventWriter {
         fluentd = builder.build(config.getHost(), config.getPort());
         LOGGER.finer(format("Created new %s, host=%s, port=%s, hashCode=%s",
                 fluentd, config.getHost(), config.getPort(), fluentd.hashCode()));
-        LOGGER.finer("Created new cached thread pool object");
-        executor = Executors.newCachedThreadPool();
     }
 
     /**
@@ -98,59 +96,66 @@ public class FluentdEventWriter implements EventWriter {
 
     private void emitData(String tag, Map<String, Object> data) throws IOException {
         LOGGER.log(Level.FINEST, "Emitting log event: {0}", new Object[] { data });
-        long retryCount = 0;
-        boolean threadInterrupted = false;
-        Future<Void> future = executor.submit(new EmitDataTask(tag, data));
 
+        boolean isThreadInterrupted = false;
         try {
-            while(!future.isDone() && !future.isCancelled()) {
+            // run Fluency.emit() in another thread to protect it from
+            // thread interrupts by Jenkins.
+            Future<Void> future = executor.submit(new FluencyEmitTask(tag, data));
+            while (true) {
                 try {
-                    LOGGER.log(Level.INFO, "Waiting for the EmitDataTask completion ...");
-                    TimeUnit.MICROSECONDS.sleep(100);
-                } catch (InterruptedException ex) {
-                    threadInterrupted = true;
+                    future.get(); // block until task is finished
+                    break;
+                }
+                catch (InterruptedException ex) {
+                    // remember that the thread has been interrupted,
+                    // but still wait for completion of the emit task
+                    isThreadInterrupted = true;
+                }
+                catch (ExecutionException ex) {
+                    Throwable cause = ex.getCause();
+                    if (cause instanceof IOException) {
+                        throw (IOException)cause;
+                    }
+                    throw new RuntimeException(cause);
                 }
             }
-
-            try {
-                if (future.isDone() || future.isCancelled()) {
-                    future.get();
-                }
-            } catch (CancellationException | ExecutionException | InterruptedException ex) {
-                LOGGER.log(Level.INFO, "Exception occurred in the 'EmitDataTask' thread: {0}", ex);
-            }
-        } finally {
-            if (threadInterrupted) {
-                // restore interrupted flag
+        }
+        finally {
+            if (isThreadInterrupted) {
+                // restore thread's interrupted status
                 Thread.currentThread().interrupt();
-                retryCount = 0;
-                while(!Thread.interrupted() && retryCount < 100) {
-                    Thread.currentThread().interrupt();
-                    retryCount++;
-                }
             }
         }
     }
 
-    private class EmitDataTask implements Callable<Void> {
-        private EventTime eventTime;
-        private int timeoutMillis = config.getEmitTimeoutMillis();
-        private IOException lastException = null;
-        private long startTimeNanos = System.nanoTime();
-        private Map<String, Object> data;
+    /**
+     * A tasks that emits data via Fluency.<p/>
+     *
+     * It is supposed to be executed in a separate thread to protect it from
+     * thread interrupts by Jenkins. Fluency has a bug that leads to loss of
+     * buffered event data in case of thread interrupt.
+     */
+    private class FluencyEmitTask implements Callable<Void> {
         private String tag;
-        private boolean threadInterrupted = false;
-        private long retryCount = 0;
-        private long threadInterruptionRetryCount = 0;
+        private Map<String, Object> data;
+        private EventTime eventTime;
 
-        EmitDataTask(String tag, Map<String, Object> data) {
+        FluencyEmitTask(String tag, Map<String, Object> data) {
             this.data = data;
             this.tag = tag;
             eventTime = getEventTime(data);
         }
 
-        public Void call() throws InterruptedException, IOException {
+        public Void call() throws IOException {
+            final int timeoutMillis = config.getEmitTimeoutMillis();
+            final long startTimeNanos = System.nanoTime();
+
+
+            boolean isThreadInterrupted = false;
             try {
+                IOException lastException = null;
+                long retryCount = 0;
                 while (true) {
                     try {
                         fluentd.emit(tag, eventTime, data);
@@ -167,21 +172,23 @@ public class FluentdEventWriter implements EventWriter {
                     }
 
                     try {
-                        long delayMicros = (long) (10_000.0 * Math.pow(1.3, (double) Math.min(this.retryCount, 18)));
+                        // Use exponential back-off that grows slowly and is
+                        // capped at a not too high value so that the retry
+                        // rate is high enough to prevent longer delays.
+                        // It's expected that Fluency's buffers run full
+                        // frequently and retrying must happen here without
+                        // adding much delay.
+                        long delayMicros = (long) (10_000.0 * Math.pow(1.3, (double) Math.min(retryCount, 18)));
                         TimeUnit.MICROSECONDS.sleep(delayMicros);
                     } catch (InterruptedException ex) {
-                        this.threadInterrupted = true;
+                        isThreadInterrupted = true;
                     }
-                    this.retryCount++;
+                    retryCount++;
                 }
             } finally {
-                if (this.threadInterrupted) {
+                if (isThreadInterrupted) {
+                    // restore thread's interrupted status
                     Thread.currentThread().interrupt();
-                    threadInterruptionRetryCount = 0;
-                    while(!Thread.interrupted() && threadInterruptionRetryCount < 100) {
-                        Thread.currentThread().interrupt();
-                        threadInterruptionRetryCount++;
-                    }
                 }
             }
             return null;
@@ -195,42 +202,97 @@ public class FluentdEventWriter implements EventWriter {
         }
     }
 
-
     @Override
-    public void close() throws IOException
+    public void close() throws Exception
     {
         try {
             this.lock.writeLock().lock();
             failIfClosed();
 
-            if (fluentd != null) {
-                try {
-                    fluentd.flush();
+            boolean isThreadInterrupted = false;
+            try {
+                // run Fluency.emit() in another thread to protect it from
+                // thread interrupts by Jenkins.
+                Future<Void> future = executor.submit(new FluencyShutdownTask());
+                while (true) {
                     try {
-                        if (!fluentd.waitUntilAllBufferFlushed(config.getMaxWaitSecondsUntilBufferFlushed())) {
-                            throw new IOException("Not all data could be flushed.");
-                        }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                        future.get(); // block until task is finished
+                        break;
                     }
-                    fluentd.close();
-                    try {
-                        if (!fluentd.waitUntilFlusherTerminated(config.getMaxWaitSecondsUntilFlusherTerminated())) {
-                            throw new IOException("Flusher not terminated.");
-                        }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                    catch (InterruptedException ex) {
+                        // remember that the thread has been interrupted,
+                        // but still wait for completion of the emit task
+                        isThreadInterrupted = true;
                     }
-                } finally {
-                    fluentd.clearBackupFiles();
+                    catch (ExecutionException ex) {
+                        Throwable cause = ex.getCause();
+                        if (cause instanceof Exception) {
+                            throw (Exception)cause;
+                        }
+                        throw new RuntimeException(cause);
+                    }
                 }
-                checkForRetryableException();
+            } finally {
+                if (isThreadInterrupted) {
+                    // restore thread's interrupted status
+                    Thread.currentThread().interrupt();
+                }
             }
+
+            checkForRetryableException();
         }
         finally {
-            this.lock.writeLock().unlock();
-            LOGGER.log(Level.INFO, "Terminated the thread pool");
             this.executor.shutdown();
+            this.executor = null;
+            this.fluentd = null;
+            this.lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * A tasks that shuts down Fluency.<p/>
+     *
+     * It is supposed to be executed in a separate thread to protect it from
+     * thread interrupts by Jenkins. Fluency has a bug that leads to loss of
+     * buffered event data in case of thread interrupt.
+     */
+    private class FluencyShutdownTask implements Callable<Void> {
+
+        @Override
+        public Void call() throws Exception {
+            boolean isThreadInterrupted = false;
+            try {
+                fluentd.flush();
+                try {
+                    if (!fluentd.waitUntilAllBufferFlushed(config.getMaxWaitSecondsUntilBufferFlushed())) {
+                        throw new Exception("Not all data could be flushed.");
+                    }
+                } catch (InterruptedException e) {
+                    isThreadInterrupted = true;
+                }
+
+                fluentd.close();
+                try {
+                    if (!fluentd.waitUntilFlusherTerminated(config.getMaxWaitSecondsUntilFlusherTerminated())) {
+                        throw new Exception("Flusher not terminated.");
+                    }
+                } catch (InterruptedException e) {
+                    isThreadInterrupted = true;
+                }
+            } finally {
+                try {
+                    fluentd.clearBackupFiles();
+                }
+                catch (Throwable t) {
+                    LOGGER.fine("Failed to clear Fluency backup files: " + t.getMessage());
+                }
+
+                if (isThreadInterrupted) {
+                    // restore thread's interrupted status
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return null;
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/fluentd/FluentdEventWriter.java
+++ b/src/main/java/io/jenkins/plugins/pipeline_elasticsearch_logs/write/fluentd/FluentdEventWriter.java
@@ -6,6 +6,12 @@ import static java.lang.String.format;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -14,7 +20,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
-import org.komamitsu.fluency.BufferFullException;
 import org.komamitsu.fluency.EventTime;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.RetryableException;
@@ -31,6 +36,7 @@ public class FluentdEventWriter implements EventWriter {
 
     private transient Fluency fluentd;
     private transient FluentdErrorHandler errorHandler;
+    private ExecutorService executor;
 
     FluentdEventWriterConfig config;
 
@@ -68,6 +74,8 @@ public class FluentdEventWriter implements EventWriter {
         fluentd = builder.build(config.getHost(), config.getPort());
         LOGGER.finer(format("Created new %s, host=%s, port=%s, hashCode=%s",
                 fluentd, config.getHost(), config.getPort(), fluentd.hashCode()));
+        LOGGER.finer("Created new cached thread pool object");
+        executor = Executors.newCachedThreadPool();
     }
 
     /**
@@ -90,46 +98,103 @@ public class FluentdEventWriter implements EventWriter {
 
     private void emitData(String tag, Map<String, Object> data) throws IOException {
         LOGGER.log(Level.FINEST, "Emitting log event: {0}", new Object[] { data });
-
-        EventTime eventTime = getEventTime(data);
-        int timeoutMillis = config.getEmitTimeoutMillis();
-        IOException lastException = null;
-        long startTimeNanos = System.nanoTime();
         long retryCount = 0;
+        boolean threadInterrupted = false;
+        Future<Void> future = executor.submit(new EmitDataTask(tag, data));
 
-        while (true) {
-            try {
-                fluentd.emit(tag, eventTime, data);
-                long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-                LOGGER.log(Level.FINEST, "Log event emitted after {0} nanoseconds", new Object[] { elapsedTimeNanos });
-                break;
-            } catch (BufferFullException ex) {
-                lastException = ex;
-            } catch (IOException ex) {
-                LOGGER.log(Level.INFO, "Exception occurred while emitting data: {0}", ex);
-            }
-
-            long elapsedMillis = (System.nanoTime() - startTimeNanos) / 1_000_000;
-            if (timeoutMillis >= 0 && elapsedMillis > timeoutMillis) {
-                throw new IOException("Failed to emit log event after " + timeoutMillis + " milliseconds. Giving up.", lastException);
+        try {
+            while(!future.isDone() && !future.isCancelled()) {
+                try {
+                    LOGGER.log(Level.INFO, "Waiting for the EmitDataTask completion ...");
+                    TimeUnit.MICROSECONDS.sleep(100);
+                } catch (InterruptedException ex) {
+                    threadInterrupted = true;
+                }
             }
 
             try {
-                long delayMicros = (long) (10_000.0 * Math.pow(1.3, (double) Math.min(retryCount, 18)));
-                TimeUnit.MICROSECONDS.sleep(delayMicros);
-            } catch (InterruptedException ex) {
-                LOGGER.log(Level.FINEST, "Exception occurred while sleeping: {0}", ex);
+                if (future.isDone() || future.isCancelled()) {
+                    future.get();
+                }
+            } catch (CancellationException | ExecutionException | InterruptedException ex) {
+                LOGGER.log(Level.INFO, "Exception occurred in the 'EmitDataTask' thread: {0}", ex);
             }
-            retryCount++;
+        } finally {
+            if (threadInterrupted) {
+                // restore interrupted flag
+                Thread.currentThread().interrupt();
+                retryCount = 0;
+                while(!Thread.interrupted() && retryCount < 100) {
+                    Thread.currentThread().interrupt();
+                    retryCount++;
+                }
+            }
         }
     }
 
-    private EventTime getEventTime(Map<String, Object> data) {
-        Instant instant = Instant.parse((String) data.get(TIMESTAMP));
-        long epochSeconds = instant.getEpochSecond();
-        long nanoSeconds = instant.getNano();
-        return EventTime.fromEpoch(epochSeconds, nanoSeconds);
+    private class EmitDataTask implements Callable<Void> {
+        private EventTime eventTime;
+        private int timeoutMillis = config.getEmitTimeoutMillis();
+        private IOException lastException = null;
+        private long startTimeNanos = System.nanoTime();
+        private Map<String, Object> data;
+        private String tag;
+        private boolean threadInterrupted = false;
+        private long retryCount = 0;
+        private long threadInterruptionRetryCount = 0;
+
+        EmitDataTask(String tag, Map<String, Object> data) {
+            this.data = data;
+            this.tag = tag;
+            eventTime = getEventTime(data);
+        }
+
+        public Void call() throws InterruptedException, IOException {
+            try {
+                while (true) {
+                    try {
+                        fluentd.emit(tag, eventTime, data);
+                        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+                        LOGGER.log(Level.FINEST, "Log event emitted after {0} nanoseconds", new Object[] { elapsedTimeNanos });
+                        break;
+                    } catch (IOException ex) {
+                        lastException = ex;
+                    }
+
+                    long elapsedMillis = (System.nanoTime() - startTimeNanos) / 1_000_000;
+                    if (timeoutMillis >= 0 && elapsedMillis > timeoutMillis) {
+                        throw new IOException("Failed to emit log event after " + timeoutMillis + " milliseconds. Giving up.", lastException);
+                    }
+
+                    try {
+                        long delayMicros = (long) (10_000.0 * Math.pow(1.3, (double) Math.min(this.retryCount, 18)));
+                        TimeUnit.MICROSECONDS.sleep(delayMicros);
+                    } catch (InterruptedException ex) {
+                        this.threadInterrupted = true;
+                    }
+                    this.retryCount++;
+                }
+            } finally {
+                if (this.threadInterrupted) {
+                    Thread.currentThread().interrupt();
+                    threadInterruptionRetryCount = 0;
+                    while(!Thread.interrupted() && threadInterruptionRetryCount < 100) {
+                        Thread.currentThread().interrupt();
+                        threadInterruptionRetryCount++;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private EventTime getEventTime(Map<String, Object> data) {
+            Instant instant = Instant.parse((String) data.get(TIMESTAMP));
+            long epochSeconds = instant.getEpochSecond();
+            long nanoSeconds = instant.getNano();
+            return EventTime.fromEpoch(epochSeconds, nanoSeconds);
+        }
     }
+
 
     @Override
     public void close() throws IOException
@@ -164,6 +229,8 @@ public class FluentdEventWriter implements EventWriter {
         }
         finally {
             this.lock.writeLock().unlock();
+            LOGGER.log(Level.INFO, "Terminated the thread pool");
+            this.executor.shutdown();
         }
     }
 


### PR DESCRIPTION
Threads might get interrupted when such step is stopped by the sleep command. Such interruptions does not allow fluency to properly flush the queued events in the buffer. Instead [an IOException is thrown.](https://github.com/komamitsu/fluency/blob/master/fluency-core/src/main/java/org/komamitsu/fluency/buffer/Buffer.java#L342)

```
java.lang.InterruptedException
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1261)
	at java.base/java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:317)
	at java.base/java.util.concurrent.LinkedBlockingQueue.put(LinkedBlockingQueue.java:330)
	at org.komamitsu.fluency.buffer.Buffer.moveRetentionBufferToFlushable(Buffer.java:338)
Caused: java.io.IOException: Failed to move retention buffer due to interruption
	at org.komamitsu.fluency.buffer.Buffer.moveRetentionBufferToFlushable(Buffer.java:342)
	at org.komamitsu.fluency.buffer.Buffer.moveRetentionBufferIfNeeded(Buffer.java:311)
	at org.komamitsu.fluency.buffer.Buffer.loadDataToRetentionBuffers(Buffer.java:208)
	at org.komamitsu.fluency.buffer.Buffer.appendMapInternal(Buffer.java:253)
	at org.komamitsu.fluency.buffer.Buffer.append(Buffer.java:280)
	at org.komamitsu.fluency.Fluency.lambda$emit$1(Fluency.java:61)
	at org.komamitsu.fluency.Fluency$Emitter.emit(Fluency.java:197)
	at org.komamitsu.fluency.Fluency.emit(Fluency.java:61)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.fluentd.FluentdEventWriter.emitData(FluentdEventWriter.java:102)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.fluentd.FluentdEventWriter.push(FluentdEventWriter.java:84)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.write.utils.SharedEventWriterFactory$EventWriterProxy.push(SharedEventWriterFactory.java:80)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticsearchSender$ElasticsearchOutputStream.eol(ElasticsearchSender.java:174)
	at hudson.console.LineTransformationOutputStream.eol(LineTransformationOutputStream.java:61)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:57)
	at io.jenkins.plugins.pipeline_elasticsearch_logs.ElasticsearchSender$ElasticsearchOutputStream.write(ElasticsearchSender.java:148)
	at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:87)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$NewlineSafeTaskListener$1.write(DurableTaskStep.java:462)
	at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:137)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$NewlineSafeTaskListener$1.write(DurableTaskStep.java:466)
	at java.base/java.io.PrintStream.write(PrintStream.java:559)
	at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:108)
	at org.apache.commons.io.output.ProxyOutputStream.write(ProxyOutputStream.java:74)
	at hudson.remoting.RemoteOutputStream.write(RemoteOutputStream.java:107)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController$WriteLog.invoke(FileMonitoringTask.java:371)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController$WriteLog.invoke(FileMonitoringTask.java:353)
	at hudson.FilePath.act(FilePath.java:1198)
	at hudson.FilePath.act(FilePath.java:1181)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController.writeLog(FileMonitoringTask.java:342)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.check(DurableTaskStep.java:601)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.run(DurableTaskStep.java:555)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

See Thread interruption in the 'workflow-durable-task-step-plugin' plugin. 

- https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/workflow-durable-task-step-2.40/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L382
- https://github.com/jenkinsci/workflow-support-plugin/blob/workflow-support-3.8/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Timeout.java#L86

As the main threads are affected by the Durable tasks and interrupted exceptions it can be beneficial to run the fluentd.emitData in a separate thread.

newCachedThreadPool is used in this implementation to re-use the existing threads in the threadpool, otherwise it creates a new thread and inject it to the threadpool. As thread creation is costly re-using threads helps the performance.